### PR TITLE
Remove @types/dotenv dev dependency

### DIFF
--- a/express-generator-typescript/lib/express-generator-typescript.js
+++ b/express-generator-typescript/lib/express-generator-typescript.js
@@ -49,7 +49,7 @@ function getDepStrings(withAuth) {
     let dependencies = 'express dotenv http-status-codes morgan cookie-parser winston ' +
         'module-alias cross-env';
     let devDependencies = 'ts-node tslint typescript nodemon find jasmine supertest ' +
-        '@types/node @types/dotenv @types/express @types/jasmine @types/find @types/morgan ' +
+        '@types/node @types/express @types/jasmine @types/find @types/morgan ' +
         '@types/cookie-parser @types/supertest fs-extra tsconfig-paths @types/jsonfile ' +
         'jsonfile';
     if (withAuth) {

--- a/sample-output/express-gen-ts/package.json
+++ b/sample-output/express-gen-ts/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.1",
-    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/find": "^0.2.1",
     "@types/jasmine": "^3.4.0",

--- a/sample-output/someProjectName/package.json
+++ b/sample-output/someProjectName/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",
-    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.1",
     "@types/find": "^0.2.1",
     "@types/jasmine": "^3.4.0",

--- a/sample-output/withAuth/package.json
+++ b/sample-output/withAuth/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@types/bcrypt": "^3.0.0",
     "@types/cookie-parser": "^1.4.2",
-    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.1",
     "@types/find": "^0.2.1",
     "@types/jasmine": "^3.4.0",


### PR DESCRIPTION
As of version 8.2.0, the [dotenv](https://github.com/motdotla/dotenv) provides types, making the inclusion of the @types/dotenv devDependency redundant. This pull request removes it from the code and the samples