### PR TITLE
throw error if tsc fails to build

### DIFF
--- a/express-generator-typescript/lib/project-files/build.js
+++ b/express-generator-typescript/lib/project-files/build.js
@@ -9,7 +9,12 @@ try {
     fs.copySync('./src/public', './dist/public');
     fs.copySync('./src/views', './dist/views');
     // Transpile the typescript files
-    childProcess.exec('tsc --build tsconfig.prod.json');
+    const proc = childProcess.exec('tsc --build tsconfig.prod.json');
+    proc.on('close', (code) => {
+        if (code !== 0) {
+            throw Error("Build failed")
+        }
+    })
 } catch (err) {
     console.log(err);
 }


### PR DESCRIPTION
this prevents docker from being successfully built while project file is failed to build and hence docker image is broken.