### PR TITLE
feat: add nodemon config with --inspect flag

### DIFF
--- a/sample-output/express-gen-ts/nodemon.json
+++ b/sample-output/express-gen-ts/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "ignore": ["src/public"],
+  "exec": "node --inspect -r ts-node/register -r tsconfig-paths/register ./src --env=development "
+}

--- a/sample-output/express-gen-ts/package.json
+++ b/sample-output/express-gen-ts/package.json
@@ -5,7 +5,7 @@
     "build": "node build.js",
     "lint": "tslint --project \"tsconfig.json\"",
     "start": "node -r module-alias/register ./dist --env=production",
-    "start:dev": "nodemon",
+    "start:dev": "nodemon --config nodemon.json",
     "test": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {

--- a/sample-output/express-gen-ts/spec/nodemon.json
+++ b/sample-output/express-gen-ts/spec/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["spec"],
   "ext": "spec.ts",
   "ignore": ["spec/support"],
-  "exec": "ts-node -r tsconfig-paths/register ./spec"
+  "exec": "node --inspect -r ts-node/register -r tsconfig-paths/register ./spec --env=test "
 }

--- a/sample-output/withAuth/nodemon.json
+++ b/sample-output/withAuth/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "ignore": ["src/public"],
+  "exec": "node --inspect -r ts-node/register -r tsconfig-paths/register ./src --env=development "
+}

--- a/sample-output/withAuth/package.json
+++ b/sample-output/withAuth/package.json
@@ -5,7 +5,7 @@
     "build": "node build.js",
     "lint": "tslint --project \"tsconfig.json\"",
     "start": "node -r module-alias/register ./dist --env=production",
-    "start:dev": "nodemon",
+    "start:dev": "nodemon --config nodemon.json",
     "test": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {

--- a/sample-output/withAuth/spec/nodemon.json
+++ b/sample-output/withAuth/spec/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["spec"],
   "ext": "spec.ts",
   "ignore": ["spec/support"],
-  "exec": "ts-node -r tsconfig-paths/register ./spec"
+  "exec": "node --inspect -r ts-node/register -r tsconfig-paths/register ./spec --env=test "
 }


### PR DESCRIPTION
Solve #25 
Add nodemon config with `--inspect` flag
Example: `node --inspect -r ts-node/register -r tsconfig-paths/register ./src --env=development`

