### PR TITLE
Add CI friendly test script to packages.json

### DIFF
--- a/express-generator-typescript/lib/auth-proj/package.json
+++ b/express-generator-typescript/lib/auth-proj/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
-    "test": "nodemon --config ./spec/nodemon.json"
+    "test": "ts-node -r tsconfig-paths/register ./spec",
+    "test:dev": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {
     "watch": ["src"],

--- a/express-generator-typescript/lib/auth-proj/spec/index.ts
+++ b/express-generator-typescript/lib/auth-proj/spec/index.ts
@@ -43,6 +43,7 @@ jasmine.onComplete((passed: boolean) => {
     } else {
         logger.err('At least one test has failed :(');
     }
+    jasmine.exitCodeCompletion(passed);
 });
 
 // Run all or a single unit-test

--- a/express-generator-typescript/lib/project-files/package.json
+++ b/express-generator-typescript/lib/project-files/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
-    "test": "nodemon --config ./spec/nodemon.json"
+    "test": "ts-node -r tsconfig-paths/register ./spec",
+    "test:dev": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {
     "watch": ["src"],

--- a/express-generator-typescript/lib/project-files/spec/index.ts
+++ b/express-generator-typescript/lib/project-files/spec/index.ts
@@ -43,6 +43,7 @@ jasmine.onComplete((passed: boolean) => {
     } else {
         logger.err('At least one test has failed :(');
     }
+    jasmine.exitCodeCompletion(passed);
 });
 
 // Run all or a single unit-test

--- a/sample-output/express-gen-ts/package.json
+++ b/sample-output/express-gen-ts/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
-    "test": "nodemon --config ./spec/nodemon.json"
+    "test": "ts-node -r tsconfig-paths/register ./spec",
+    "test:dev": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {
     "watch": [

--- a/sample-output/express-gen-ts/spec/index.ts
+++ b/sample-output/express-gen-ts/spec/index.ts
@@ -43,6 +43,7 @@ jasmine.onComplete((passed: boolean) => {
     } else {
         logger.err('At least one test has failed :(');
     }
+    jasmine.exitCodeCompletion(passed);
 });
 
 // Run all or a single unit-test

--- a/sample-output/with-auth/package.json
+++ b/sample-output/with-auth/package.json
@@ -6,7 +6,8 @@
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
-    "test": "nodemon --config ./spec/nodemon.json"
+    "test": "ts-node -r tsconfig-paths/register ./spec",
+    "test:dev": "nodemon --config ./spec/nodemon.json"
   },
   "nodemonConfig": {
     "watch": [

--- a/sample-output/with-auth/spec/index.ts
+++ b/sample-output/with-auth/spec/index.ts
@@ -43,6 +43,7 @@ jasmine.onComplete((passed: boolean) => {
     } else {
         logger.err('At least one test has failed :(');
     }
+    jasmine.exitCodeCompletion(passed);
 });
 
 // Run all or a single unit-test


### PR DESCRIPTION
Howdy,

I propose we make the following changes to the template.

Rename the current test script to `test:dev`:
`
"test:dev": "nodemon --config ./spec/nodemon.json",
`

Add a new CI friendly test script:
`"test": "ts-node -r tsconfig-paths/register ./spec",`

With a line added to `jasmine.onComplete()` also:
`jasmine.exitCodeCompletion(passed);`

With these changed, one can use `yarn test` in CI/CD and automated scripts while still using `yarn test:dev` with hotreloading via nodemon for development.

Related issues: #22 