### PR TITLE
Fixed "'.' is not recognized as an internal or external command" error on Windows

### DIFF
--- a/express-generator-typescript/lib/auth-proj/package.json
+++ b/express-generator-typescript/lib/auth-proj/package.json
@@ -2,12 +2,12 @@
   "name": "with-auth",
   "version": "0.0.0",
   "scripts": {
-    "build": "ts-node build.ts",
+    "build": "npx ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "npx ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [
@@ -17,7 +17,7 @@
     "ignore": [
       "src/public"
     ],
-    "exec": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./src"
+    "exec": "npx ts-node --files -r tsconfig-paths/register ./src"
   },
   "_moduleAliases": {
     "@services": "dist/services",

--- a/express-generator-typescript/lib/auth-proj/package.json
+++ b/express-generator-typescript/lib/auth-proj/package.json
@@ -7,7 +7,7 @@
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "npx ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [

--- a/express-generator-typescript/lib/auth-proj/package.json
+++ b/express-generator-typescript/lib/auth-proj/package.json
@@ -2,12 +2,12 @@
   "name": "with-auth",
   "version": "0.0.0",
   "scripts": {
-    "build": "./node_modules/.bin/ts-node build.ts",
+    "build": "ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [

--- a/express-generator-typescript/lib/auth-proj/package.json
+++ b/express-generator-typescript/lib/auth-proj/package.json
@@ -7,7 +7,7 @@
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "npx ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [
@@ -17,7 +17,7 @@
     "ignore": [
       "src/public"
     ],
-    "exec": "npx ts-node --files -r tsconfig-paths/register ./src"
+    "exec": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./src"
   },
   "_moduleAliases": {
     "@services": "dist/services",

--- a/express-generator-typescript/lib/project-files/package.json
+++ b/express-generator-typescript/lib/project-files/package.json
@@ -2,12 +2,12 @@
   "name": "express-gen-ts",
   "version": "0.0.0",
   "scripts": {
-    "build": "ts-node build.ts",
+    "build": "npx ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "ts-node -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "npx ts-node -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [

--- a/express-generator-typescript/lib/project-files/package.json
+++ b/express-generator-typescript/lib/project-files/package.json
@@ -2,12 +2,12 @@
   "name": "express-gen-ts",
   "version": "0.0.0",
   "scripts": {
-    "build": "./node_modules/.bin/ts-node build.ts",
+    "build": "ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "./node_modules/.bin/ts-node -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "ts-node -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [

--- a/express-generator-typescript/lib/socket-io/package.json
+++ b/express-generator-typescript/lib/socket-io/package.json
@@ -2,12 +2,12 @@
   "name": "chat-app",
   "version": "0.0.0",
   "scripts": {
-    "build": "ts-node build.ts",
+    "build": "npx ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "npx ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [

--- a/express-generator-typescript/lib/socket-io/package.json
+++ b/express-generator-typescript/lib/socket-io/package.json
@@ -2,12 +2,12 @@
   "name": "chat-app",
   "version": "0.0.0",
   "scripts": {
-    "build": "./node_modules/.bin/ts-node build.ts",
+    "build": "ts-node build.ts",
     "lint": "eslint . --ext .ts",
     "start": "node -r module-alias/register ./dist --env=production",
     "start:dev": "nodemon",
     "test": "nodemon --config ./spec/nodemon.json",
-    "test:no-reloading": "./node_modules/.bin/ts-node --files -r tsconfig-paths/register ./spec"
+    "test:no-reloading": "ts-node --files -r tsconfig-paths/register ./spec"
   },
   "nodemonConfig": {
     "watch": [


### PR DESCRIPTION
This works on windows. Should technically work on Linux & Mac as well, I haven't tested it yet but doing that in the meanwhile.

Fix for Issue #60 