### PR TITLE
Update users.spec.ts to fix expected error messages

### DIFF
--- a/lib/project-files/spec/tests/users.spec.ts
+++ b/lib/project-files/spec/tests/users.spec.ts
@@ -102,14 +102,15 @@ describe('UserRouter', () => {
     });
 
     // Missing param
+    const expectedErrorMessage = `${ValidatorErr}"user".`;
     it('should return a JSON object with an error message of ' + 
-    `"${ValidatorErr}" and a status code of "${BAD_REQUEST}" if the user ` + 
+    `"${expectedErrorMessage}" and a status code of "${BAD_REQUEST}" if the user ` + 
     'param was missing.', (done) => {
       // Call api
       callApi({})
         .end((_: Error, res: Response) => {
           expect(res.status).toBe(BAD_REQUEST);
-          expect(res.body.error).toBe(ValidatorErr);
+          expect(res.body.error).toBe(expectedErrorMessage);
           done();
         });
     });
@@ -139,14 +140,15 @@ describe('UserRouter', () => {
       });
 
     // Param missing
+    const expectedErrorMessage = `${ValidatorErr}"user".`;
     it('should return a JSON object with an error message of ' +
-    `"${ValidatorErr}" and a status code of "${BAD_REQUEST}" if the user ` + 
+    `"${expectedErrorMessage}" and a status code of "${BAD_REQUEST}" if the user ` + 
     'param was missing.', (done) => {
       // Call api
       callApi({})
         .end((_: Error, res: Response) => {
           expect(res.status).toBe(BAD_REQUEST);
-          expect(res.body.error).toBe(ValidatorErr);
+          expect(res.body.error).toBe(expectedErrorMessage);
           done();
         });
     });
@@ -200,12 +202,13 @@ describe('UserRouter', () => {
     });
 
     // Invalid param
+    const expectedErrorMessage = `${ValidatorErr}"id".`;
     it(`should return a status code of "${BAD_REQUEST}" and return an error ` + 
-    `message of "${ValidatorErr}" if the id was not a valid number`, (done) => {
+    `message of "${expectedErrorMessage}" if the id was not a valid number`, (done) => {
       callApi('horse' as unknown as number)
         .end((_: Error, res: Response) => {
           expect(res.status).toBe(BAD_REQUEST);
-          expect(res.body.error).toBe(ValidatorErr);
+          expect(res.body.error).toBe(expectedErrorMessage);
           done();
         });
     });


### PR DESCRIPTION
When running the test from a freshly generated project, 3 tests will fail because the error message generated by the validator will not match the expected message. The former will contain a field name, while the latter does not. This change attempts to fix that by adding the appropriate field name into the expected message.