### PR TITLE
refactor: remove return on res

### DIFF
--- a/lib/project-files-auth/src/routes/middleware/adminMw.ts
+++ b/lib/project-files-auth/src/routes/middleware/adminMw.ts
@@ -38,9 +38,10 @@ async function adminMw(
     return next();
   // Return an unauth error if user is not an admin
   } else {
-    return res
+    res
       .status(HttpStatusCodes.UNAUTHORIZED)
       .json({ error: USER_UNAUTHORIZED_ERR });
+    return;
   }
 }
 


### PR DESCRIPTION
Hello, 

This PR removes the return that is directly called on
```ts
return res
      .status(HttpStatusCodes.UNAUTHORIZED)
      .json({ error: USER_UNAUTHORIZED_ERR });
```
in order to avoid the type error at `routes/index.ts` when the project is generated with --with-auth flag, since a middleware expected to have a `void` return type, while with current implementation the `adminMw` return type is ```Promise<void | IRes>```. Also moved the return below the res to avoid any further code execution while the response is already sent. This is also an image of the TS error: 
![Screenshot from 2024-10-06 00-30-26](https://github.com/user-attachments/assets/b72ec4ad-7214-4a28-8ae6-653e7b94cfc7)


