### PR TITLE
Remove deprecated unstable_ts_config flag from lint script

### DIFF
--- a/lib/project-files/package.json
+++ b/lib/project-files/package.json
@@ -6,7 +6,7 @@
     "clean-install": "rm -rf ./node_modules && rm -r package-lock.json && npm i",
     "dev": "NODE_ENV=development ts-node ./src",
     "dev:hot": "nodemon --exec \"npm run dev\" --watch ./src --ext .ts",
-    "lint": "eslint --flag unstable_ts_config",
+    "lint": "eslint .",
     "start": "NODE_ENV=production node -r ./config.js ./dist",
     "test": "NODE_ENV=test ts-node ./spec",
     "test:hot": "nodemon --exec \"npm run test\" --watch ./src --watch ./spec --ext .ts",


### PR DESCRIPTION
removes the deprecated unstable_ts_config flag from the lint script in package.json to ensure compatibility with ESLint v9.18.0 and above.